### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Out of the box, both the `fn1` and `fn2` modifiers only change to multimedia key
 - Set your keyboard to Windios/Android mode
 - Set the options for the kernel module
 
-        echo "s hid_apple fnmode=2" > /etc/modprobe.d/hid_apple.conf
+        echo "options hid_apple fnmode=2" | sudo tee /etc/modprobe.d/hid_apple.conf
         sudo update-initramfs -u
         reboot
 


### PR DESCRIPTION
Two fixes.

1. `echo "s ...."`  is wrong. It's `echo "options ...." as per [this Arch wiki entry](https://wiki.archlinux.org/title/Apple_Keyboard#Function_keys_do_not_work)
2. If you assume a user is to use `sudo` for a `sudo update-initramfs -u` then in the previous command there should be a `sudo` too. Added `| sudo tee` to keep the command syntactically similar to how it was before.

Thanks for the guide, it was bothering me that keys weren't working!